### PR TITLE
fix: upgrade mongoose to 8.9.5 to resolve 5 security vulnerabilities

### DIFF
--- a/baak-dataload-sql/package.json
+++ b/baak-dataload-sql/package.json
@@ -17,7 +17,7 @@
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "latest-version": "^5.1.0",
-    "mongoose": "5.13.14",
+    "mongoose": "^8.9.5",
     "morgan": "^1.10.0",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",


### PR DESCRIPTION
## Summary
This PR upgrades mongoose from 5.13.14 to 8.9.5 to fix 5 security vulnerabilities:

- CVE-2022-2564 (Critical, 9.8) - Prototype Pollution
- CVE-2023-3696 (Critical, 9.8) - Prototype Pollution
- CVE-2024-53900 (Critical, 9.1) - Search Injection
- CVE-2025-23061 (Critical, 9.0) - Search Injection (incomplete fix for CVE-2024-53900)
- CVE-2025-2306 (Medium, 5.9) - Search Injection

## Changes
- Updated baak-dataload-sql/package.json: mongoose 5.13.14 → ^8.9.5

Closes #175